### PR TITLE
fix: targetDir

### DIFF
--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -45,7 +45,7 @@ module.exports = class MonitorStats {
       cb();
     });
 
-    // // CHECK UNPURE CSS
+    // CHECK UNPURE CSS
     compiler.plugin('emit', (compilation, cb) => {
       const css = compilation.chunks
         .map(chunk => chunk.files)
@@ -71,9 +71,10 @@ module.exports = class MonitorStats {
     });
 
     // CHECK IF TARGET DIRECTORY EXISTS...
-    if (!fs.existsSync(target)) {
+    const targetDir = path.dirname(target)
+    if (!fs.existsSync(targetDir)) {
       // ...make directory if it does not
-      fs.mkdirSync(path.resolve(__dirname, '../..', 'monitor'));
+      fs.mkdirSync(targetDir);
       data = [];
     } else {
       // ...get existing data if it does

--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -75,10 +75,14 @@ module.exports = class MonitorStats {
     if (!fs.existsSync(targetDir)) {
       // ...make directory if it does not
       fs.mkdirSync(targetDir);
-      data = [];
-    } else {
+    }
+    
+    // CHECK IF TARGET FILE EXISTS...
+    if (fs.existsSync(target)) {
       // ...get existing data if it does
       data = JSON.parse(fs.readFileSync(target, { encoding: 'utf8' }));
+    } else {
+      data = [];
     }
 
     compiler.plugin('done', (stats) => {


### PR DESCRIPTION
Currently, custom target dir is not working if not exists (And if exists second build/run fails). This PR uses `path.dirname` to fix problems.