### PR TITLE
fix: handle empty assets

### DIFF
--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -31,6 +31,7 @@ module.exports = class MonitorStats {
         .map(chunk => chunk.files)
         .reduce((arr, el) => arr.concat(el))
         .filter(file => /\.js($|\?)/.test(file))
+        .filter(file => compilation.assets[file])
         .forEach((file) => {
           const source = compilation.assets[file].source();
           const minified = source.split(/\r\n|\r|\n/).length < 25;
@@ -45,12 +46,13 @@ module.exports = class MonitorStats {
       cb();
     });
 
-    // // CHECK UNPURE CSS
+    // CHECK UNPURE CSS
     compiler.plugin('emit', (compilation, cb) => {
       const css = compilation.chunks
         .map(chunk => chunk.files)
         .reduce((arr, el) => arr.concat(el))
         .filter(file => /\.css($|\?)/.test(file))
+        .filter(file => compilation.assets[file])
         .reduce((concat, file) => {
           const sourceCSS = compilation.assets[file].source();
           return concat += sourceCSS;
@@ -65,7 +67,7 @@ module.exports = class MonitorStats {
           return concat += sourceJs;
         }, '');
 
-      const purified = purifycss(js, css, { minify: false });
+      const purified = purifycss(js || '', css || '', { minify: false });
       pureSize = purified.length;
       cb();
     });

--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -62,6 +62,7 @@ module.exports = class MonitorStats {
         .map(chunk => chunk.files)
         .reduce((arr, el) => arr.concat(el))
         .filter(file => /\.js($|\?)/.test(file))
+        .filter(file => compilation.assets[file])
         .reduce((concat, file) => {
           const sourceJs = compilation.assets[file].source();
           return concat += sourceJs;


### PR DESCRIPTION
While working on Nuxt.js integration, there are some virtual assets (without real source and exictence in `compilation.assets`). This PR ignores them using a simple `filter` pipe step. Also handles conditions when either `js` or `css` passed into purify are `undefined`. With this PR Webpack monitor should be working fine with nuxt webpack configs too 🎉 