### PR TITLE
Add support for flat stats.modules array

### DIFF
--- a/plugin/npm-module/utils/parser.js
+++ b/plugin/npm-module/utils/parser.js
@@ -1,7 +1,7 @@
 module.exports = (stats, target) => {
   stats.assets = stats.assets.filter(asset => asset.name !== target);
 
-  return {
+  const result = {
     timeStamp: Date.now(),
     time: stats.time,
     hash: stats.hash,
@@ -28,4 +28,20 @@ module.exports = (stats, target) => {
     })),
 
   };
+
+  if (stats.modules) {
+    stats.modules.forEach(module => {
+      if (module.chunks) {
+        module.chunks.forEach(chunk => {
+          result.chunks[chunk].modules.push({
+            name: module.name,
+            size: module.size,
+            id: module.id,
+          });
+        });
+      }
+    });
+  }
+
+  return result;
 };


### PR DESCRIPTION
Not sure what part of my webpack config causes stats to be generated like this. My guess is either webpack v2 or CommonsChunkPlugin. Instead of each chunk having a modules array, there's a separate flat stats.modules array, with each module object having an array of chunks it belongs to, represented by their index in stats.chunks array.

With this change, parser.js will iterate through the stats.modules array and assign modules to their chunks in the return value before returning it.

It has been tested manually.