### PR TITLE
Gracefully handle PurifyCSS errors

### DIFF
--- a/client/views/recommendations/components/PurifyCss.jsx
+++ b/client/views/recommendations/components/PurifyCss.jsx
@@ -8,12 +8,14 @@ const PurifyCss = (props) => {
   const build = props.build;
   if (build.unPureCssSize === undefined) return <div />;
   const now = (build.pureCssSize / build.unPureCssSize) * 100;
+  const hasBothSizes = build.pureCssSize && build.unPureCssSize;
   return (
     <Panel>
       <PanelHeader title="Remove Unused CSS Classes" />
       <p className="subtitle">The following file size reduction estimates are based on the <a href="https://www.npmjs.com/package/purifycss">Purify CSS module</a></p>
-      <FileReport now={now} />
-      <PanelData totalSize={build.unPureCssSize} optSize={build.pureCssSize} getBytes={props.getBytes} />
+      {hasBothSizes && <FileReport now={now} />}
+      {hasBothSizes && <PanelData totalSize={build.unPureCssSize} optSize={build.pureCssSize} getBytes={props.getBytes} />}
+      {build.purifyCssError && <p className="subtitle">PurifyCSS error: {build.purifyCssError}. Unable to display recommendat</p>}
     </Panel>
   );
 };

--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -24,6 +24,7 @@ module.exports = class MonitorStats {
     let unPureSize;
     let pureSize;
     let data;
+    let purifyCssError;
 
     // CHECK MINIFICATION
     compiler.plugin('emit', (compilation, cb) => {
@@ -68,8 +69,13 @@ module.exports = class MonitorStats {
           return concat += sourceJs;
         }, '');
 
-      const purified = purifycss(js || '', css || '', { minify: false });
-      pureSize = purified.length;
+      try {
+        const purified = purifycss(js || '', css || '', { minify: false });
+        pureSize = purified.length;
+      } catch (e) {
+        purifyCssError = e.reason;
+      }
+
       cb();
     });
 
@@ -110,12 +116,11 @@ module.exports = class MonitorStats {
                 asset.minified = minify.minified;
               }
             });
-          });
+          }); 
           // Add purify css data
-          if (pureSize) {
-            parsed.pureCssSize = pureSize;
-            parsed.unPureCssSize = unPureSize;
-          }
+          parsed.pureCssSize = pureSize;
+          parsed.unPureCssSize = unPureSize;
+          parsed.purifyCssError = purifyCssError;
 
           data.push(parsed);
         }


### PR DESCRIPTION
Wrapped the PurifyCSS call in try..catch and added error display on recommendations page of the dashboard.

Tested manually.

A PurifyCSS error should be easy to reproduce on a project using url-loader and/or svg-url-loader.