### PR TITLE
Guard logging to console with debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ const WebpackMonitor = require('webpack-monitor');
 
 plugins: [
   new WebpackMonitor({
-    capture: true, // -> default 'true'
+    capture: true, // default -> true
     target: '../monitor/myStatsStore.json', // default -> '../monitor/stats.json'
-    launch: true, // -> default 'false'
+    launch: true, // default -> false
     port: 3030, // default -> 8081
+    debug: true, // default -> false
   }),
 ],
 ```
@@ -40,6 +41,7 @@ plugins: [
 `target` specify where to save your build data
 `launch` will fire up a local server and launch the webpack monitor analysis tool
 `port` optionally set the port for local server
+`debug` optionally output debug information to the console
 
 ## Contributing
 To contribute to `webpack-monitor`, fork the repository and clone it to your machine then install dependencies with `npm install`. If you're interested in joining the Webpack Monitor team as a contributor, feel free to message one of us directly!

--- a/plugin/npm-module/README.md
+++ b/plugin/npm-module/README.md
@@ -20,10 +20,11 @@ const WebpackMonitor = require('webpack-monitor');
 
 plugins: [
   new WebpackMonitor({
-    capture: true, // -> default 'true'
+    capture: true, // default -> true
     target: '../monitor/myStatsStore.json', // default -> '../monitor/stats.json'
-    launch: true, // -> default 'false'
+    launch: true, // default -> false
     port: 3030, // default -> 8081
+    debug: true, // default -> false
   }),
 ],
 ```
@@ -32,6 +33,7 @@ plugins: [
 `target` specify where to save your build data
 `launch` will fire up a local server and launch the webpack monitor analysis tool
 `port` optionally set the port for local server
+`debug` optionally output debug information to the console
 
 ## Contributing
 To contribute to `webpack-monitor`, fork the repository and clone it to your machine then install dependencies with `npm install`. If you're interested in joining the Webpack Monitor team as a contributor, feel free to message one of us directly!

--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -14,6 +14,7 @@ module.exports = class MonitorStats {
       launch: false,
       capture: true,
       port: 8081,
+      debug: false,
     }, options);
   }
 
@@ -101,7 +102,7 @@ module.exports = class MonitorStats {
           parsed.assets.length !== prev.assets.length ||
           parsed.chunks.length !== prev.chunks.length
         ) {
-          console.log('Writing new build');
+          if (this.options.debug) console.log('Writing new build');
           // Add minified data
           parsed.assets.forEach((asset) => {
             isMinified.forEach((minify) => {

--- a/plugin/npm-module/utils/server.js
+++ b/plugin/npm-module/utils/server.js
@@ -3,12 +3,12 @@ const path = require('path');
 const opener = require('opener');
 const colors = require('colors');
 
-module.exports = (data, port, update) => {
+module.exports = (data, port, update, pluginOptions) => {
   const app = express();
   const url = `http://localhost:${port}/`;
-  const options = {
+  const options = Object.assign({
     root: path.join(__dirname, '..', 'build'),
-  };
+  }, pluginOptions);
 
   app.use(express.static(options.root));
   app.use('/css', express.static(path.join(__dirname, '..', 'build', 'css')));
@@ -23,7 +23,9 @@ module.exports = (data, port, update) => {
 
   app.listen(port, () => {
     opener(url);
-    console.log(colors.bold('\nWebpack-Monitor'), `is running on port ${port}!`);
-    console.log(colors.italic.red('Press ctrl C to exit'));
+    if (options.debug) {
+      console.log(colors.bold('\nWebpack-Monitor'), `is running on port ${port}!`);
+      console.log(colors.italic.red('Press ctrl C to exit'));
+    }
   });
 };


### PR DESCRIPTION
For tools that wrap the output of Webpack, having plugins output directly to the console with no option to disable can mess with their special output.

This PR guards logging to the console by adding a new `debug` option, which is disabled by default.