### PR TITLE
adds  `chunkModuls: true` to toJson options (issue #60)

### DIFF
--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -10,7 +10,10 @@ module.exports = class MonitorStats {
   constructor(options) {
     this.options = Object.assign({
       target: '../monitor/stats.json',
-      jsonOpts: { source: false },
+      jsonOpts: { 
+        source: false,
+        chunkModules: true
+      },
       launch: false,
       capture: true,
       port: 8081,


### PR DESCRIPTION
prior to webpack v3.0, Stats.toJson's option had the `chunkModules` property with default value of false. (after v3.0 [#5039](https://github.com/webpack/webpack/pull/5039) its default value is true). SunBurstChart needs the modules property for the chuncks for rendering the chart, therefor in the toJson options the `chunkModules: true` property was added to allow rendering the chart for older webpack versions.