### PR TITLE
minor improvement: hides the navigation arrow to the next/previous build when it is currently at the last/first build.

### DIFF
--- a/build/css/style.css
+++ b/build/css/style.css
@@ -353,6 +353,13 @@ a:hover {
   cursor: pointer;
 }
 
+/* hide the arrow but allow it to take its space in the layout */
+.arrow.inactive {
+  opacity: 0;
+  pointer-events: none;
+  cursor: default;
+}
+
 /* SPINNER */
 .loader,
 .loader:after {

--- a/client/views/cards/Cards.jsx
+++ b/client/views/cards/Cards.jsx
@@ -55,7 +55,15 @@ class Cards extends React.Component {
     if (totalSize.toString().length > 3 && totalSize.toString().length < 7) totalSize = `${Math.floor(totalSize / 1000)}KB`;
     if (totalSize.toString().length > 6) totalSize = `${(totalSize / 1000000).toFixed(2)}MB`;
 
-    const indexData = <span><span onClick={this.props.handleDecrement} className="arrow">&#9666;</span>{index + 1}<span onClick={this.props.handleIncrement} className="arrow">&#9656;</span></span>;
+    // arrows to the next/prev build,
+    // hide arrow(s) if it is currently at the last/first build therefore no navigation posibility
+    const indexData = (
+      <span>
+        <span onClick={this.props.handleDecrement} className={"arrow " + (this.props.activeBuild === 0 ? "inactive" : "")}>&#9666;</span>
+        {index + 1}
+        <span onClick={this.props.handleIncrement} className={"arrow " + (this.props.activeBuild === this.props.build.length - 1 ? "inactive" : "")}>&#9656;</span>
+      </span>
+    );
 
     const cardData = [totalSize, chunksTotal, modulesTotal, assetsTotal, errorsTotal, indexData];
 


### PR DESCRIPTION

![build_arrow_nav](https://user-images.githubusercontent.com/8455548/32099178-911e2284-bb0f-11e7-8d6e-4cb4fd8919bc.jpg)
this arrow would not shown when it's at the first build and can't show any previous builds.
Same for the next button on the last build.