### PR TITLE
minor fix for the 'File Size' column name wich was 'Size Name'

### DIFF
--- a/client/views/build-data/components/Modules.jsx
+++ b/client/views/build-data/components/Modules.jsx
@@ -24,7 +24,7 @@ const Modules = (props) => {
               <thead>
                 <tr>
                   <th>File Name</th>
-                  <th>Size Name</th>
+                  <th>File Size</th>
                   <th>Percentage</th>
                 </tr>
               </thead>


### PR DESCRIPTION
![size_col_title](https://user-images.githubusercontent.com/8455548/32099325-253b6e18-bb10-11e7-9df6-99faeb8b520f.jpg)
marked column title in the source tables would be changed to "**File Size**", similar as in "Changes from Previous Build" table.