### PR TITLE
Add option to suppress source maps from build stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,16 @@ plugins: [
     target: '../monitor/myStatsStore.json', // default -> '../monitor/stats.json'
     launch: true, // -> default 'false'
     port: 3030, // default -> 8081
+    excludeSourceMaps: true // default 'true'
   }),
 ],
 ```
 
-`capture` will collect stats on the build where meaningful changes have occured. We do not capture build data where the build does not differ from most recent build on file.  
-`target` specify where to save your build data  
-`launch` will fire up a local server and launch the webpack monitor analysis tool  
-`port` optionally set the port for local server  
+`capture` will collect stats on the build where meaningful changes have occured. We do not capture build data where the build does not differ from most recent build on file.
+`target` specify where to save your build data
+`launch` will fire up a local server and launch the webpack monitor analysis tool
+`port` optionally set the port for local server
+`excludeSourceMaps` excludes emitted source maps from the build stats
 
 ## Contributing
 To contribute to `webpack-monitor`, fork the repository and clone it to your machine then install dependencies with `npm install`. If you're interested in joining the Webpack Monitor team as a contributor, feel free to message one of us directly!

--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -10,13 +10,14 @@ module.exports = class MonitorStats {
   constructor(options) {
     this.options = Object.assign({
       target: '../monitor/stats.json',
-      jsonOpts: { 
+      jsonOpts: {
         source: false,
         chunkModules: true
       },
       launch: false,
       capture: true,
       port: 8081,
+      excludeSourceMaps: true
     }, options);
   }
 
@@ -82,7 +83,7 @@ module.exports = class MonitorStats {
       // ...make directory if it does not
       fs.mkdirSync(targetDir);
     }
-    
+
     // CHECK IF TARGET FILE EXISTS...
     if (fs.existsSync(target)) {
       // ...get existing data if it does
@@ -95,7 +96,7 @@ module.exports = class MonitorStats {
       if (this.options.capture) {
         stats = stats.toJson(jsonOpts);
         const prev = data[data.length - 1];
-        const parsed = parseStats(stats, target);
+        const parsed = parseStats(stats, target, this.options);
         // Check if new data exists
         if (
           !data.length ||

--- a/plugin/npm-module/utils/parser.js
+++ b/plugin/npm-module/utils/parser.js
@@ -1,5 +1,10 @@
-module.exports = (stats, target) => {
-  stats.assets = stats.assets.filter(asset => asset.name !== target);
+module.exports = (stats, target, options) => {
+  stats.assets = stats.assets.filter(asset => {
+    if (asset.name === target) return false
+    // Filter out source maps by testing for file name ending with .map
+    if (options.excludeSourceMaps) return !/\.map$/.test(asset.name)
+    return true
+  })
 
   return {
     timeStamp: Date.now(),


### PR DESCRIPTION
Excludes source maps from build stats by default by adding a check to the `parseStats` for asset names ending in `.map`.

Added configuration option `excludeSourceMaps` which is default true.

Closes #88 