### PR TITLE
test: add Jest testing setup for plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tool for monitoring webpack optimization metrics through the development process",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "stats": "webpack --env production --profile --json > stats.json",
     "start": "webpack-dev-server --env development",
     "build": "webpack --env development",
@@ -35,6 +35,7 @@
     "glob": "^7.1.2",
     "html-webpack-plugin": "^2.30.1",
     "html-webpack-template": "^5.6.0",
+    "jest": "^22.0.4",
     "json-loader": "^0.5.7",
     "opener": "^1.4.3",
     "purify-css": "^1.2.5",

--- a/plugin/npm-module/.npmignore
+++ b/plugin/npm-module/.npmignore
@@ -1,0 +1,2 @@
+__mocks__
+*.spec.js

--- a/plugin/npm-module/utils/__mocks__/mock-stats.js
+++ b/plugin/npm-module/utils/__mocks__/mock-stats.js
@@ -1,0 +1,59 @@
+// Mock a typical stats output, specifying what calculated valuables should be so
+// that the test isn't brittle
+
+const sumAssetSize = (sum, size) => sum + size
+const sourceMapAssetsSizes = [2894415]
+const assetSizes = [3535, 2864415]
+const summedMapAssetsSize = sourceMapAssetsSizes.reduce(sumAssetSize, 0)
+const summedAssetsSize = assetSizes.reduce(sumAssetSize, 0)
+
+export default () => ({
+  allAssetsSize: summedAssetsSize + summedMapAssetsSize,
+  allAssetsLength: sourceMapAssetsSizes.length + assetSizes.length,
+  sourceAssetsSize: summedAssetsSize,
+  sourceAssetsLength: assetSizes.length,
+  stats: {
+    time: 9406, // build time in ms
+    hash: 'b71025d48ee86bda14d6', // the build hash
+    errors: [],
+    assets: [
+      {
+        chunks: [],
+        name: 'logo.png',
+        size: assetSizes[0],
+      },
+      {
+        chunks: [0], // References the included chunks by id
+        name: 'app.js',
+        size: assetSizes[1],
+      },
+      {
+        chunks: [0],
+        name: 'app.js.map',
+        size: sourceMapAssetsSizes[0],
+      },
+    ],
+    chunks: [
+      {
+        size: 978983,
+        files: ['test-missing-modules.js'],
+      },
+      {
+        size: 2864415,
+        files: ['app.js'],
+        modules: [
+          {
+            name: './node_modules/react/react.js',
+            size: 56,
+            id: 0,
+          },
+          {
+            name: './node_modules/babel-runtime/helpers/classCallCheck.js',
+            size: 208,
+            id: 1,
+          },
+        ],
+      },
+    ],
+  },
+})

--- a/plugin/npm-module/utils/parser.spec.js
+++ b/plugin/npm-module/utils/parser.spec.js
@@ -1,0 +1,40 @@
+import parser from './parser'
+import mockStats from './__mocks__/mock-stats'
+
+const target = '/usr/local/code/webpackmonitor/monitor/stats.json'
+
+describe('utils/parser', () => {
+  it('includes the stats meta data in parsed data', () => {
+    const { stats } = mockStats()
+    const result = parser(stats, target, {})
+
+    expect(stats.time).toEqual(result.time)
+    expect(stats.hash).toEqual(result.hash)
+    expect(stats.errors).toEqual(result.errors)
+  })
+
+  it('includes source maps when excludeSourceMaps is false', () => {
+    const { stats, allAssetsSize, allAssetsLength } = mockStats()
+    const result = parser(stats, target, { excludeSourceMaps: false })
+
+    expect(result.assets.length).toEqual(allAssetsLength)
+    expect(result.size).toEqual(allAssetsSize)
+  })
+
+  it('filters out source maps when excludeSourceMaps is true', () => {
+    const { stats, sourceAssetsSize, sourceAssetsLength } = mockStats()
+    const result = parser(stats, target, { excludeSourceMaps: true })
+
+    expect(result.assets.length).toEqual(sourceAssetsLength)
+    expect(result.size).toEqual(sourceAssetsSize)
+  })
+
+  it('ensures every chunk has a modules array', () => {
+    const { stats } = mockStats()
+    const result = parser(stats, target, {})
+
+    result.chunks.forEach(chunk => {
+      expect(Array.isArray(chunk.modules)).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
This PR adds Jest to the project for testing, including a starting set of tests for the parser.

Additional configuration can be added to enable testing of client React components.

@roachjc I used single quotes, no semis and trailing commas everywhere, that looked like the style of the repo? (Have you used Prettier? It is amazing 😍)

I also added an `.npmignore` in the plugin directory to prevent publishing of the mocks and test files.

<img width="516" alt="screen shot 2017-12-29 at 10 37 52 am" src="https://user-images.githubusercontent.com/8461733/34445215-2bcd0f18-ec87-11e7-90da-30bbaeb0a38b.png">
