### PR TITLE
Add a standalone server

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -14,7 +14,7 @@ class App extends React.Component {
 
   // Get build data
   componentDidMount() {
-    fetch('/getstats')
+    fetch('getstats')
     .then(res => res.json())
     .then((build) => {
       this.setState({ build, activeBuild: build.length - 1 });

--- a/client/index.dev.jsx
+++ b/client/index.dev.jsx
@@ -1,7 +1,22 @@
 import React from 'react';
+import { render } from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
 import Header from './containers/Header';
 import Main from './containers/Main';
 import build from './../monitor/stats.json';
+
+
+// App retrieves data with fetch from getstats route on plugin server
+render(
+  (
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  ),
+  document.getElementById('root'),
+);
+
 
 class App extends React.Component {
   constructor() {

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,29 +1,15 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
-import AppDev from './AppDev';
 import App from './App';
 
-const env = process.env.NODE_ENV;
 
-if (env === 'development') {
-  // AppDev imports a local JSON file as demo data
-  render(
-    (
-      <BrowserRouter>
-        <AppDev />
-      </BrowserRouter>
-    ),
-    document.getElementById('root'),
-  );
-} else {
-  // App retrieves data with fetch from getstats route on plugin server
-  render(
-    (
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    ),
-    document.getElementById('root'),
-  );
-}
+// App retrieves data with fetch from getstats route on plugin server
+render(
+  (
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  ),
+  document.getElementById('root'),
+);

--- a/plugin/npm-module/README.md
+++ b/plugin/npm-module/README.md
@@ -33,6 +33,21 @@ plugins: [
 `launch` will fire up a local server and launch the webpack monitor analysis tool  
 `port` optionally set the port for local server
 
+
+## Standalone server
+If you just want to display the stats, without having to rebuild your project, `webpack-monitor` publishes the `webpack-monitor` executable to just launch the server.
+
+```
+  Usage: webpack-monitor [options] [filename]
+
+  Options:
+
+    -V, --version     output the version number
+    -p --port [port]  The port to run the server on (default: 8081)
+    -f --filename     The json file to load stats from - Resolved relative to where the command is executed
+    -h, --help        output usage information
+```
+
 ## Contributing
 To contribute to `webpack-monitor`, fork the repository and clone it to your machine then install dependencies with `npm install`. If you're interested in joining the Webpack Monitor team as a contributor, feel free to message one of us directly!
 

--- a/plugin/npm-module/bin/webpack-monitor.js
+++ b/plugin/npm-module/bin/webpack-monitor.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const commander = require("commander");
+const path = require("path");
+
+const program = new commander.Command("webpack-monitor");
+const server = require("../utils/server");
+const pkg = require("../package.json");
+
+const main = (module.exports = opts => {
+  opts = opts || {};
+  const argv = typeof opts.argv === "undefined" ? process.argv : opts.argv;
+
+  program
+    .version(pkg.version)
+    .option(
+      "-p --port [port]",
+      "The port to run the server on",
+      /^[0-9]{2,}/,
+      8081
+    )
+    .option(
+      "-f --filename",
+      "The json file to load stats from - Resolved relative to where the command is executed"
+    )
+    .usage("[options] [filename]")
+    .parse(argv);
+
+  let filename = program.filename || program.args[0] || "./monitor/stats.json";
+  filename = path.resolve(process.cwd(), filename);
+  console.log(
+    "Launching Webpack monitor with filename '" +
+      filename +
+      "' and port " +
+      program.port
+  );
+  server(filename, program.port);
+});
+
+if (require.main === module) {
+  main();
+}

--- a/plugin/npm-module/monitor.js
+++ b/plugin/npm-module/monitor.js
@@ -131,7 +131,7 @@ module.exports = class MonitorStats {
         }
       }
       fs.writeFile(target, JSON.stringify(data, null, 2), () => {
-        if (this.options.launch) server(data, this.options.port);
+        if (this.options.launch) server(target, this.options.port);
       });
     });
   }

--- a/plugin/npm-module/package.json
+++ b/plugin/npm-module/package.json
@@ -6,6 +6,7 @@
   "author": "Jon Roach, Gordon Yu, Balal Zuhair",
   "license": "MIT",
   "main": "monitor.js",
+  "bin": "./bin/webpack-monitor.js",
   "dependencies": {
     "babel-core": "^6.26.0",
     "colors": "^1.1.2",

--- a/plugin/npm-module/package.json
+++ b/plugin/npm-module/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "colors": "^1.1.2",
+    "commander": "^2.19.0",
     "express": "^4.15.5",
     "mkdirp": "^0.5.1",
     "opener": "^1.4.3",

--- a/plugin/npm-module/utils/server.js
+++ b/plugin/npm-module/utils/server.js
@@ -1,33 +1,33 @@
-const express = require("express");
-const fs = require("fs");
-const path = require("path");
-const opener = require("opener");
-const colors = require("colors");
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const opener = require('opener');
+const colors = require('colors');
 
 module.exports = (target, port, update) => {
   const app = express();
   const url = `http://localhost:${port}/`;
   const options = {
-    root: path.join(__dirname, "..", "build")
+    root: path.join(__dirname, '..', 'build')
   };
 
   app.use(express.static(options.root));
-  app.use("/css", express.static(path.join(__dirname, "..", "build", "css")));
+  app.use('/css', express.static(path.join(__dirname, '..', 'build', 'css')));
 
-  app.get("/", (req, res) => {
-    res.sendFile("index.html", options);
+  app.get('/', (req, res) => {
+    res.sendFile('index.html', options);
   });
 
-  app.get("/getstats", (req, res) => {
-    res.json(JSON.parse(fs.readFileSync(target, { encoding: "utf8" })));
+  app.get('/getstats', (req, res) => {
+    res.json(JSON.parse(fs.readFileSync(target, { encoding: 'utf8' })));
   });
 
   app.listen(port, () => {
     opener(url);
     console.log(
-      colors.bold("\nWebpack-Monitor"),
+      colors.bold('\nWebpack-Monitor'),
       `is running on port ${port}!`
     );
-    console.log(colors.italic.red("Press ctrl C to exit"));
+    console.log(colors.italic.red('Press ctrl C to exit'));
   });
 };

--- a/plugin/npm-module/utils/server.js
+++ b/plugin/npm-module/utils/server.js
@@ -1,32 +1,33 @@
-const express = require('express');
-const path = require('path');
-const opener = require('opener');
-const colors = require('colors');
+const express = require("express");
+const fs = require("fs");
+const path = require("path");
+const opener = require("opener");
+const colors = require("colors");
 
-module.exports = (data, port, update) => {
+module.exports = (target, port, update) => {
   const app = express();
   const url = `http://localhost:${port}/`;
   const options = {
-    root: path.join(__dirname, '..', 'build')
+    root: path.join(__dirname, "..", "build")
   };
 
   app.use(express.static(options.root));
-  app.use('/css', express.static(path.join(__dirname, '..', 'build', 'css')));
+  app.use("/css", express.static(path.join(__dirname, "..", "build", "css")));
 
-  app.get('/', (req, res) => {
-    res.sendFile('index.html', options);
+  app.get("/", (req, res) => {
+    res.sendFile("index.html", options);
   });
 
-  app.get('/getstats', (req, res) => {
-    res.json(data);
+  app.get("/getstats", (req, res) => {
+    res.json(JSON.parse(fs.readFileSync(target, { encoding: "utf8" })));
   });
 
   app.listen(port, () => {
     opener(url);
     console.log(
-      colors.bold('\nWebpack-Monitor'),
+      colors.bold("\nWebpack-Monitor"),
       `is running on port ${port}!`
     );
-    console.log(colors.italic.red('Press ctrl C to exit'));
+    console.log(colors.italic.red("Press ctrl C to exit"));
   });
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const WebpackMonitor = require('./plugin/npm-module/monitor');
 
 const PATHS = {
   app: path.join(__dirname, 'client/index.jsx'),
+  appDev: path.join(__dirname, 'client/index.dev.jsx'),
   build: path.join(__dirname, 'build')
 };
 
@@ -16,7 +17,6 @@ module.exports = env => {
       entry: {
         app: PATHS.app
       },
-
       resolve: {
         extensions: ['.js', 'json', '.jsx']
       },
@@ -57,6 +57,9 @@ module.exports = env => {
   ]);
 
   const development = {
+    entry: {
+      app: PATHS.appDev
+    },
     output: {
       path: PATHS.build,
       filename: '[name].js'


### PR DESCRIPTION
This adds a standalone server that can be run ad-hoc without having to build the project. 

I would love to use this for a CI/CD workflow where I have the stats server running in the same docker as my review app. 

This change means we are reloading the stats file each time /getstats is called, but honestly holding it in memory probably isn't the best idea anyways.