### PR TITLE
fix failing tests because jsdom now needs jest config to have a url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "react-bootstrap": "^0.31.3",
     "react-dom": "^15.6.1",
     "react-router-dom": "^4.2.2"
+  },
+  "jest": {
+    "testURL": "http://localhost:3030"
   }
 }


### PR DESCRIPTION
when runing tests, it fails with the error: `SecurityError: localStorage is not available for opaque origins`
it seems jsdom needs a url defined in the testing environment configuration (see https://github.com/jsdom/jsdom/issues/2304)
this adds a jest config to packgge.json and adds some non default `testUrl` to it.